### PR TITLE
Updated signature for process method

### DIFF
--- a/src/groovy/asset/pipeline/sass/SassProcessor.groovy
+++ b/src/groovy/asset/pipeline/sass/SassProcessor.groovy
@@ -108,7 +108,7 @@ class SassProcessor extends AbstractProcessor {
         }
     }
 
-    def process(input, assetFile) {
+    String process(String input, AssetFile assetFile) {
         def grailsApplication = Holders.getGrailsApplication()
 
         if(!this.precompiler) {


### PR DESCRIPTION
Will not compile with Grails 2.4.4 and AssetPipeline 2.0.15 without explicitly declaring types for the process method's signature and return type

```
  [groovyc] org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
  [groovyc] /Users/popcorn/.grails/2.4.4/projects/user-web/plugins/sass-asset-pipeline-1.9.1/src/groovy/asset/pipeline/sass/SassProcessor.groovy: 34: Can't have an abstract method in a non-abstract class. The class 'asset.pipeline.sass.SassProcessor' must be declared abstract or the method 'java.lang.String process(java.lang.String, asset.pipeline.AssetFile)' must be implemented.
  [groovyc]  @ line 34, column 1.
  [groovyc]    @Log4j
  [groovyc]    ^
  [groovyc] 
| Compiling 20 source files.
| Error Compilation error: startup failed:
/tmp/plugins/sass-asset-pipeline-1.9.1/src/groovy/asset/pipeline/sass/SassProcessor.groovy: 34: Can't have an abstract method in a non-abstract class. The class 'asset.pipeline.sass.SassProcessor' must be declared abstract or the method 'java.lang.String process(java.lang.String, asset.pipeline.AssetFile)' must be implemented.
 @ line 34, column 1.
   @Log4j
```
