### PR TITLE
Removing jars & gems from production war

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -9,3 +9,12 @@ eventAssetPrecompileStart = { assetConfig ->
     }
     configHolder.config.sass.resolveGems = false
 }
+// Remove the JRuby jar and gems directory before the war is bundled
+eventCreateWarStart = { warName, stagingDir ->
+	if (grailsEnv == "production") {
+		grailsConsole.log "Removing JRuby jar and gems used for Sass compilation in Dev"
+		Ant.delete(file:"${stagingDir}/WEB-INF/lib/jruby-complete-1.7.11.jar")
+		Ant.delete(file:"${stagingDir}/WEB-INF/lib/jruby-container-0.4.0.jar")
+		Ant.delete(dir:"${stagingDir}/WEB-INF/classes/gems")
+	}
+}


### PR DESCRIPTION
Since the built assets are in the war, I believe the plugin itself doesn't need to go in. I tried other ways of excluding the plugin (export = false in BuildConfig, and grails.plugin.excludes in Config) but only createWarStart worked for me (with grails 2.5.0). Seems like excluding these files would be generally useful.